### PR TITLE
Transform Councilmans from São Paulo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem 'mongo', '~> 2.4', '>= 2.4.1'
 gem 'test-unit', '~> 3.1', '>= 3.1.3'
+gem 'mysql2', '~> 0.4', '>= 0.4.6'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gem 'mongo', '~> 2.4', '>= 2.4.1'
 gem 'test-unit', '~> 3.1', '>= 3.1.3'
-gem 'mysql2', '~> 0.4', '>= 0.4.6'
+gem 'bson', '~> 4.2', '>= 4.2.1'
+gem 'mysql2', '~> 0.4.6'

--- a/bin/councilman/ETL/export_to_csv.rb
+++ b/bin/councilman/ETL/export_to_csv.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/brazil/councilman/sp/extract/ct/extractor'
+require_relative '../../../lib/brazil/councilman/sp/extract/extractor'
 require "csv"
 
 # This file is used to import councilman though command line
@@ -11,7 +11,9 @@ require "csv"
 puts 'Importing councilman debits....'
 
 extractor = SPCouncilman::Extractor.new
-File.write("councilman.csv", extractor.data.map(&:to_csv).join)
+data = extractor.get_data
+
+File.write("councilman.csv", data.map(&:to_csv).join)
 puts data if ENV == 'development'
 
 

--- a/bin/councilman/ETL/export_to_csv.rb
+++ b/bin/councilman/ETL/export_to_csv.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/brazil/councilman/sp/extract/extractor'
+require_relative '../../lib/brazil/councilman/sp/extract/ct/extractor'
 require "csv"
 
 # This file is used to import councilman though command line

--- a/bin/councilman/ETL/extract_debits.rb
+++ b/bin/councilman/ETL/extract_debits.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/brazil/councilman/sp/extract/extractor'
+require_relative '../../../lib/brazil/councilman/sp/extract/extractor'
 
 # This file is used to import councilman though command line
 # Dependencies:
@@ -7,11 +7,9 @@ require_relative '../../lib/brazil/councilman/sp/extract/extractor'
 # Execute command to use:
 #   ruby bin/import_councilman_debits.rb
 
-puts 'Importing councilman debits....'
+puts 'Extracting councilman debits....'
 
 extractor = SPCouncilman::Extractor.new
 data = extractor.dump_debit
-puts data if ENV == 'development'
 
-
-puts 'It\'s finished.'
+puts data.length.to_s + ' Debits imported.'

--- a/bin/councilman/ETL/transform_debits_to_mysql.rb
+++ b/bin/councilman/ETL/transform_debits_to_mysql.rb
@@ -1,0 +1,17 @@
+require_relative '../../../lib/brazil/councilman/sp/transform/transformer'
+
+# This file is used to import councilman though command line
+# Dependencies:
+#   lib/brazil/councilman/sp/transform/transformer
+#
+# Execute command to use:
+#   ruby bin/transform_debits_to_mysql.rb
+
+puts 'Transforming councilman debits....'
+
+# Setup
+transformer = SPCouncilman::Transformer.new
+
+# Act
+data = transformer.save_debits
+puts data.length.to_s + ' Debits transformed'

--- a/bin/councilman/crawl_sp_councilman.rb
+++ b/bin/councilman/crawl_sp_councilman.rb
@@ -1,0 +1,10 @@
+
+# This file is used to import councilman though command line
+# Dependencies:
+#   lib/brazil/councilman/sp/transform/transformer
+#
+# Execute command to use:
+#   ruby bin/crawl_sp_councilman.rb
+
+require_relative 'ETL/extract_debits'
+require_relative 'ETL/transform_debits_to_mysql'

--- a/bin/councilman/transform_debits_to_mysql.rb
+++ b/bin/councilman/transform_debits_to_mysql.rb
@@ -1,7 +1,0 @@
-require_relative '../../lib/brazil/councilman/sp/transform/transformer'
-
-# Setup
-transformer = SPCouncilman::Transformer.new
-
-# Act
-saved_number = transformer.save_debits

--- a/bin/councilman/transform_debits_to_mysql.rb
+++ b/bin/councilman/transform_debits_to_mysql.rb
@@ -1,0 +1,7 @@
+require_relative '../../lib/brazil/councilman/sp/transform/transformer'
+
+# Setup
+transformer = SPCouncilman::Transformer.new
+
+# Act
+saved_number = transformer.save_debits

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,6 @@ services:
         image: mysql:latest
         environment:
          - MYSQL_ROOT_PASSWORD=servidor
-         - MYSQL_DATABASE=opendata
+         - MYSQL_DATABASE=your-pass
         ports:
           - "3307:3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     mysqldb:
         image: mysql:latest
         environment:
-         - MYSQL_ROOT_PASSWORD=root
-         - MYSQL_DATABASE=servidor
+         - MYSQL_ROOT_PASSWORD=servidor
+         - MYSQL_DATABASE=opendata
         ports:
           - "3307:3306"

--- a/lib/brazil/councilman/sp/extract/db_extract.rb
+++ b/lib/brazil/councilman/sp/extract/db_extract.rb
@@ -15,7 +15,7 @@ module SPCouncilman
 
     def get_debits
       debits = []
-      @collection.find({}).each { |k| debits << k }
+      @collection.find({}, {:sort => {'time'=> -1}, :limit => 1}).each { |k| debits << k }
       debits
     end
   end

--- a/lib/brazil/councilman/sp/extract/db_extract.rb
+++ b/lib/brazil/councilman/sp/extract/db_extract.rb
@@ -12,5 +12,11 @@ module SPCouncilman
     def initialize
       super(MONGO_DB_SETTINGS[$env], :extract_councilman)
     end
+
+    def get_debits
+      debits = []
+      @collection.find({}).each { |k| debits << k }
+      debits
+    end
   end
 end

--- a/lib/brazil/councilman/sp/extract/extractor.rb
+++ b/lib/brazil/councilman/sp/extract/extractor.rb
@@ -19,15 +19,18 @@ module SPCouncilman
       # Set up
       @requester = SPCouncilman::Requester.new(OPEN_DATA_URLS['brazil']['councilman']['sp']['debits'])
       @db = SPCouncilman::DbExtract.new
-      @data = @requester.get_debits
     end
 
     def dump_debit
-      @data.each do |el|
-        el.each do |x|
-          @db.insert(x)
-        end
-      end
+      # Setup
+      data = @requester.get_debits
+      time = Time.now.getutc
+
+      # ACT
+      @db.insert({:time => time, :debits => data})
+
+      # Return
+      data
     end
   end
 end

--- a/lib/brazil/councilman/sp/extract/extractor.rb
+++ b/lib/brazil/councilman/sp/extract/extractor.rb
@@ -21,6 +21,10 @@ module SPCouncilman
       @db = SPCouncilman::DbExtract.new
     end
 
+    def get_data
+      @requester.get_debits
+    end
+
     def dump_debit
       # Setup
       data = @requester.get_debits

--- a/lib/brazil/councilman/sp/extract/requester.rb
+++ b/lib/brazil/councilman/sp/extract/requester.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'json'
-
+require_relative '../../../../../lib/settings'
 
 # This class is used to recovery councilman data from open data
 # and save json on mongo
@@ -28,7 +28,7 @@ module SPCouncilman
       @uri_actual_list.each do |uri_by_year|
         uri_by_year[1].each do |uri|
           content = do_request(uri[1])
-          all_content << content
+          all_content.concat(content)
         end
       end
       all_content
@@ -45,17 +45,18 @@ module SPCouncilman
     end
 
     def get_all_uris_to_debits(url)
-      year = 2015
+      from_year = OPEN_DATA_URLS['brazil']['councilman']['sp']['from_year']
+      to_year = OPEN_DATA_URLS['brazil']['councilman']['sp']['to_year']
       uris = {}
 
-      while year <= 2017 do
-        uris.merge!({year => {}})
+      while from_year <= to_year do
+        uris.merge!({from_year => {}})
 
-        13.times do |month|
-          next if month == 0
-          uris[year].merge!({ month => URI.parse(url + "ano=#{year}&mes=#{month}")})
+        12.times do |month|
+          month += 1
+          uris[from_year].merge!({ month => URI.parse(url + "ano=#{from_year}&mes=#{month}")})
         end
-        year += 1
+        from_year += 1
       end
 
       uris

--- a/lib/brazil/councilman/sp/transform/db_transform.rb
+++ b/lib/brazil/councilman/sp/transform/db_transform.rb
@@ -1,0 +1,17 @@
+require_relative '../../../../../lib/mysql_db_manager'
+require_relative '../../../../../lib/settings'
+
+
+# This class is used to connect with mysql and use transform collection
+#
+# Example of use:
+#   db = SPCouncilman::DbTransform.new
+#   db.insert(your_array_or_hash={}, "table_name")
+
+module SPCouncilman
+  class DbTransform < MysqlDbManager
+    def initialize
+      super(MYSQL_DB_SETTINGS[$env])
+    end
+  end
+end

--- a/lib/brazil/councilman/sp/transform/parser.rb
+++ b/lib/brazil/councilman/sp/transform/parser.rb
@@ -1,0 +1,33 @@
+
+# This class is used to parse councilman information obtained
+# from extract DB
+# Dependencies:
+#   extract/db_extract
+#
+# Example of use:
+#   parser = SPCouncilman::Parser.new
+module SPCouncilman
+  class Parser
+    def get_debit_object_to_save_in_mysql(debit)
+      {
+        :debit =>{
+          :code => debit['Chave'],
+          :filename => debit['NomeArquivo'],
+          :cost_center_code => debit['CENTROCUSTOSID'],
+          :cost_object => debit['DESPESA'],
+          :department => debit['DEPARTAMENTO'],
+          :department_type => debit['TIPODEPARTAMENTO'],
+          :year => debit['ANO'],
+          :month => debit['MES'],
+          :cnpj => debit['CNPJ'],
+          :provider => debit['FORNECEDOR'],
+          :value => debit['VALOR'],
+        },
+        :councilman => {
+            :name => debit['VEREADOR']
+        }
+      }
+    end
+  end
+end
+

--- a/lib/brazil/councilman/sp/transform/parser.rb
+++ b/lib/brazil/councilman/sp/transform/parser.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 
 # This class is used to parse councilman information obtained
 # from extract DB
@@ -20,7 +21,7 @@ module SPCouncilman
           :year => debit['ANO'],
           :month => debit['MES'],
           :cnpj => debit['CNPJ'],
-          :provider => debit['FORNECEDOR'],
+          :provider => debit['FORNECEDOR'].sub("'", ""),
           :value => debit['VALOR'],
         },
         :councilman => {

--- a/lib/brazil/councilman/sp/transform/transformer.rb
+++ b/lib/brazil/councilman/sp/transform/transformer.rb
@@ -27,7 +27,7 @@ module SPCouncilman
       all_raw_debits = @db_extract.get_debits # TODO: improve
 
       # Insert into councilmans_debits table each one debit
-      all_raw_debits.each do |raw_debit|
+      all_raw_debits[0]['debits'].each do |raw_debit|
         # Parse open data information to our context
         debits_to_save = @parser.get_debit_object_to_save_in_mysql(raw_debit)
 

--- a/lib/brazil/councilman/sp/transform/transformer.rb
+++ b/lib/brazil/councilman/sp/transform/transformer.rb
@@ -63,8 +63,8 @@ module SPCouncilman
     def get_or_create_councilman_debits(debit, councilman_id)
       debit[:councilman_id] = councilman_id
       puts debit if $env == 'development'
+      # TODO: Create get to scape duplication
       contact_information = @db_transform.create(debit, 'councilman_debits')
-      # @db.insert(contact_information)
     end
 
 

--- a/lib/brazil/councilman/sp/transform/transformer.rb
+++ b/lib/brazil/councilman/sp/transform/transformer.rb
@@ -61,13 +61,20 @@ module SPCouncilman
     end
 
     def get_or_create_councilman_debits(debit, councilman_id)
+      # Get Councilman
       debit[:councilman_id] = councilman_id
-      puts debit if $env == 'development'
-      # TODO: Create get to scape duplication
-      contact_information = @db_transform.create(debit, 'councilman_debits')
+      where = debit
+      where.delete(:value)
+      query = @db_transform.get(where, 'councilman_debits')
+
+      if query[:rows_affected] == 0
+        contact_information = @db_transform.create(debit, 'councilman_debits')
+        query = @db_transform.get(where, 'councilman_debits')
+      end
+
+      result = query[:result].each(:as => :hash) {|el| el}
+      result[0]
     end
-
-
   end
 end
 

--- a/lib/brazil/councilman/sp/transform/transformer.rb
+++ b/lib/brazil/councilman/sp/transform/transformer.rb
@@ -1,0 +1,73 @@
+require_relative '../extract/db_extract'
+require_relative 'db_transform'
+require_relative 'parser'
+
+# This class is used to parse and save transformed data from open data
+# Dependencies:
+#   db_transform
+#   parser
+#
+# Example of use:
+#   transformer = SPCouncilman::Transformer.new
+#   transformer.save
+
+module SPCouncilman
+  class Transformer
+    def initialize
+      # Set up
+      @parser = SPCouncilman::Parser.new
+      @db_transform = SPCouncilman::DbTransform.new
+      @db_extract = SPCouncilman::DbExtract.new
+    end
+
+    # Save debits from extract database to transform database and here is
+    # location on we normalize that information.
+    def save_debits
+      # Get All raw debits from open data saved on our mongodb database
+      all_raw_debits = @db_extract.get_debits # TODO: improve
+
+      # Insert into councilmans_debits table each one debit
+      all_raw_debits.each do |raw_debit|
+        # Parse open data information to our context
+        debits_to_save = @parser.get_debit_object_to_save_in_mysql(raw_debit)
+
+        # Here we need to get or create councilman to create FK in debits
+        councilman = get_or_create_councilman(debits_to_save[:councilman][:name], 1, 1)
+
+        # Create debits with councilman_id
+        debits = get_or_create_councilman_debits(debits_to_save[:debit], councilman[0]['id'])
+      end
+    end
+
+    def get_or_create_councilman(name, city_id, state_id)
+      # Get Councilman
+      query = @db_transform.get({ 'name' => name }, 'councilman')
+
+      # if councilman not exist
+      if query[:rows_affected] == 0
+        # Save councilman
+        to_save = {
+            :name => name,
+            :city_id => city_id,
+            :state_id => state_id
+        }
+        @db_transform.create(to_save, 'councilman')
+
+        # Get councilman after insertion
+        query = @db_transform.get({ :name => name }, 'councilman')
+      end
+      councilman = query[:result].each(:as => :hash) {|el| el}
+      councilman
+    end
+
+    def get_or_create_councilman_debits(debit, councilman_id)
+      debit[:councilman_id] = councilman_id
+      puts debit if $env == 'development'
+      contact_information = @db_transform.create(debit, 'councilman_debits')
+      # @db.insert(contact_information)
+    end
+
+
+  end
+end
+

--- a/lib/mongo_db_manager.rb
+++ b/lib/mongo_db_manager.rb
@@ -21,6 +21,7 @@ class MongoDbManager
   def insert(doc, key=nil)
     to_save = key ? { key => doc } : doc
     result = @collection.insert_one(to_save)
+    result
   end
 
   def get(key)

--- a/lib/mysql_db_manager.rb
+++ b/lib/mysql_db_manager.rb
@@ -1,0 +1,48 @@
+require 'mysql2'
+
+# This class is used to connect and interact with mysql
+#
+# Example of use:
+#   db = MysqlDbManager.new(MYSQL_DB_SETTINGS)
+#   db.save('your-data-here')
+
+
+class MysqlDbManager
+
+  def initialize(settings)
+    @client = Mysql2::Client.new(
+        :host => settings['host'],
+        :username => settings['username'],
+        :password => settings['password'],
+        :port => settings['port'],
+        :database => settings['name']
+    )
+  end
+
+  def query(query_string)
+    data = @client.query(query_string)
+    rows_affected
+  end
+
+  def save(object_to_save, table_name)
+    columns = ''
+    values = ''
+
+    object_to_save.each do |k, v|
+      # Add "," when add more than one
+      columns.concat(', ') if columns != ''
+      values.concat(', ') if values != ''
+
+      # Default concat
+      columns.concat(k)
+      values.concat("'" + v + "'")
+    end
+
+    query_string = "INSERT INTO #{table_name} (#{columns}) VALUES (#{values});"
+    query(query_string)
+  end
+
+  def rows_affected
+    {'rows_affected' => @client.affected_rows()}
+  end
+end

--- a/lib/mysql_db_manager.rb
+++ b/lib/mysql_db_manager.rb
@@ -20,11 +20,18 @@ class MysqlDbManager
   end
 
   def query(query_string)
-    data = @client.query(query_string)
-    rows_affected
+    result = @client.query(query_string)
+    rows_affected(result)
   end
 
-  def save(object_to_save, table_name)
+  def rows_affected(result)
+    {
+        :rows_affected => @client.affected_rows(),
+        :result => result
+    }
+  end
+
+  def create(object_to_save, table_name)
     columns = ''
     values = ''
 
@@ -34,15 +41,30 @@ class MysqlDbManager
       values.concat(', ') if values != ''
 
       # Default concat
-      columns.concat(k)
-      values.concat("'" + v + "'")
+      columns.concat(k.to_s)
+      values.concat('"' + v.to_s + '"')
     end
 
     query_string = "INSERT INTO #{table_name} (#{columns}) VALUES (#{values});"
     query(query_string)
   end
 
-  def rows_affected
-    {'rows_affected' => @client.affected_rows()}
+  def get(where, table_name)
+    where_string = ''
+
+    where.each do |k, v|
+      # Add "," when add more than one
+      where_string.concat('AND ') if where_string != ''
+
+      # Default concat
+      where_string.concat(k.to_s)
+      where_string.concat('=')
+      where_string.concat("'" + v.to_s + "'")
+    end
+
+    query_string = "SELECT * FROM #{table_name} WHERE #{where_string};"
+    result = query(query_string)
   end
+
+
 end

--- a/lib/mysql_db_manager.rb
+++ b/lib/mysql_db_manager.rb
@@ -54,7 +54,7 @@ class MysqlDbManager
 
     where.each do |k, v|
       # Add "," when add more than one
-      where_string.concat('AND ') if where_string != ''
+      where_string.concat(' AND ') if where_string != ''
 
       # Default concat
       where_string.concat(k.to_s)

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -10,7 +10,9 @@ OPEN_DATA_URLS = {
         'parliamentarians' => 'http://legis.senado.leg.br/dadosabertos/senador/lista/atual',
         'councilman' => {
             'sp' => {
-                'debits' => 'https://app-sisgvconsulta-prd.azurewebsites.net/ws/ws2.asmx/ObterDebitoVereadorJSON?'
+                'debits' => 'https://app-sisgvconsulta-prd.azurewebsites.net/ws/ws2.asmx/ObterDebitoVereadorJSON?',
+                'from_year' => 2016, # used to define period to import
+                'to_year' => 2017, # used to define period to import
             }
         }
     }

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -15,12 +15,6 @@ OPEN_DATA_URLS = {
         }
     }
 }
-# PARLIAMENTARIANS_URL = 'http://legis.senado.leg.br/dadosabertos/senador/lista/atual'
-# COUNCILMAN_URL = {
-#     'sp' => {
-#         'debits' => 'https://app-sisgvconsulta-prd.azurewebsites.net/ws/ws2.asmx/ObterDebitoVereadorJSON?'
-#     }
-# }
 
 # Enviroment (development, production or tests)
 $env = 'production'
@@ -50,18 +44,24 @@ MYSQL_DB_SETTINGS = {
     'production' => {
         'name' => "opendata",
         'host' => "localhost",
-        'port' => "27017",
+        'port' => "3306",
+        'username' => "root",
+        'password' => "servidor",
     },
 
     'development' => {
         'name' => "opendata_development",
         'host' => "localhost",
-        'port' => "27017",
+        'port' => "3306",
+        'username' => "root",
+        'password' => "servidor",
     },
 
     'test' => {
         'name' => "opendata_test",
         'host' => "localhost",
-        'port' => "27017",
+        'port' => "3306",
+        'username' => "root",
+        'password' => "servidor",
     },
 }

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -11,7 +11,7 @@ OPEN_DATA_URLS = {
         'councilman' => {
             'sp' => {
                 'debits' => 'https://app-sisgvconsulta-prd.azurewebsites.net/ws/ws2.asmx/ObterDebitoVereadorJSON?',
-                'from_year' => 2016, # used to define period to import
+                'from_year' => 2016, # used to defined period to import
                 'to_year' => 2017, # used to define period to import
             }
         }

--- a/test/unit/brazil/councilman/sp/extract/test_councilman_db_extract.rb
+++ b/test/unit/brazil/councilman/sp/extract/test_councilman_db_extract.rb
@@ -21,5 +21,16 @@ module TestSPCouncilman
       # Assert
       assert_equal("extract_councilman", db.collection.name)
     end
+
+    def test_get_debits
+      # Setup
+      db = SPCouncilman::DbExtract.new
+
+      # ACT
+      debits = db.get_debits
+
+      # Assert
+      assert_equal("extract_councilman", db.collection.name)
+    end
   end
 end

--- a/test/unit/brazil/councilman/sp/test_sp_councilman.rb
+++ b/test/unit/brazil/councilman/sp/test_sp_councilman.rb
@@ -1,3 +1,7 @@
+# Extract
 require_relative 'extract/test_councilman_db_extract'
 require_relative 'extract/test_councilman_extractor'
 require_relative 'extract/test_councilman_requester'
+
+# Transform
+require_relative 'transform/test_councilman_db_transform'

--- a/test/unit/brazil/councilman/sp/transform/test_councilman_db_transform.rb
+++ b/test/unit/brazil/councilman/sp/transform/test_councilman_db_transform.rb
@@ -1,0 +1,17 @@
+require_relative '../../../../../../lib/brazil/councilman/sp/transform/db_transform'
+require 'test/unit'
+
+# This unit test is related to SPCouncilman::DbTransform class
+module TestSPCouncilman
+  class TestDbTransform < Test::Unit::TestCase
+    # Test successful connection with mysql
+    def test_connection
+      # Setup
+      db = SPCouncilman::DbTransform.new
+
+      # Assertion
+      assert_not_nil(db)
+      assert_equal(SPCouncilman::DbTransform, db.class)
+    end
+  end
+end

--- a/test/unit/brazil/councilman/sp/transform/test_councilman_parser.rb
+++ b/test/unit/brazil/councilman/sp/transform/test_councilman_parser.rb
@@ -30,7 +30,7 @@ module TestSPCouncilman
       # Assertion
       assert_not_nil(raw)
       assert_not_nil(raw.has_key? "filename")
-      assert_not_nil(raw.has_key? "key")
+      assert_not_nil(raw.has_key? "code")
       assert_not_nil(raw.has_key? "value")
     end
 

--- a/test/unit/brazil/councilman/sp/transform/test_councilman_parser.rb
+++ b/test/unit/brazil/councilman/sp/transform/test_councilman_parser.rb
@@ -1,0 +1,38 @@
+require_relative '../../../../../../lib/brazil/councilman/sp/transform/parser'
+require 'test/unit'
+
+# This unit test is related to SPCouncilman::Parser class
+module TestSPCouncilman
+  class TestParser < Test::Unit::TestCase
+
+    # Test get raw councilman debits from extract DB
+    def test_get_raw_debits
+      # Setup
+      parser = SPCouncilman::Parser.new
+      debit = {
+          "Chave": "1222",
+          "NomeArquivo": "20150100000000000000000000222.HTML",
+          "CENTROCUSTOSID": 222,
+          "DEPARTAMENTO": "GABINETE DE VEREADOR",
+          "TIPODEPARTAMENTO": 1,
+          "VEREADOR": "ABOU ANNI",
+          "ANO": 2015,
+          "MES": 1,
+          "DESPESA": "COMBUSTIVEL",
+          "CNPJ": "43.900.851/0001-01",
+          "FORNECEDOR": "PROTOTIPO AUTO POSTO LTDA.",
+          "VALOR": 300
+      }
+
+      # Act
+      raw = parser.get_debit_object_to_save_in_mysql(debit)
+
+      # Assertion
+      assert_not_nil(raw)
+      assert_not_nil(raw.has_key? "filename")
+      assert_not_nil(raw.has_key? "key")
+      assert_not_nil(raw.has_key? "value")
+    end
+
+  end
+end

--- a/test/unit/brazil/councilman/sp/transform/test_councilman_transformer.rb
+++ b/test/unit/brazil/councilman/sp/transform/test_councilman_transformer.rb
@@ -1,0 +1,21 @@
+require_relative '../../../../../../lib/brazil/councilman/sp/transform/transformer'
+require 'test/unit'
+
+# This unit test is related to SPCouncilman::Transformer class
+module TestSPCouncilman
+  class TestTransformer < Test::Unit::TestCase
+
+    # Test save data transformed into db
+    def test_save_debits
+      # Setup
+      transformer = SPCouncilman::Transformer.new
+
+      # Act
+      saved_number = transformer.save_debits
+
+      # Assertion
+      assert_not_nil(saved_number)
+      assert_equal(81, saved_number)
+    end
+  end
+end

--- a/test/unit/brazil/councilman/sp/transform/test_councilman_transformer.rb
+++ b/test/unit/brazil/councilman/sp/transform/test_councilman_transformer.rb
@@ -17,5 +17,17 @@ module TestSPCouncilman
       assert_not_nil(saved_number)
       assert_equal(81, saved_number)
     end
+
+    def test_get_raw_debits
+      # Setup
+      transformer = SPCouncilman::Transformer.new
+
+      # Act
+      saved_number = transformer.
+
+      # Assertion
+      assert_not_nil(saved_number)
+      assert_equal(81, saved_number)
+    end
   end
 end

--- a/test/unit/brazil/parliamentarians/transform/test_parliamentarians_db_transform.rb
+++ b/test/unit/brazil/parliamentarians/transform/test_parliamentarians_db_transform.rb
@@ -11,6 +11,7 @@ module TestParliamentarians
 
       # Assertion
       assert_not_nil(db)
+      assert_equal(Parliamentarians::DbTransform, db.class)
     end
 
     # Test verify existence of :transform_parliamentarians collection

--- a/test/unit/test_mongo_db_manager.rb
+++ b/test/unit/test_mongo_db_manager.rb
@@ -2,8 +2,8 @@ require 'test/unit'
 require_relative '../../lib/mongo_db_manager'
 require_relative '../../lib/settings'
 
-# This unit test is related to Parliamentarians::MongoDbManager class
-module TestParliamentarians
+# This unit test is related to MongoDbManager class
+module Test
   class TestMongoDbManager < Test::Unit::TestCase
 
     # Test the presence of mongo test settings
@@ -28,12 +28,13 @@ module TestParliamentarians
     end
 
     # Test successful connection with mongo
-    def test_connection_with_mongo_extract
+    def test_connection_with_mongo
       # Setup
       db = MongoDbManager.new(MONGO_DB_SETTINGS['test'], :parliamentarians)
 
       # Assertion
       assert_not_nil(db)
+      assert_equal(MongoDbManager, db.class)
     end
 
     # Test successful object saved in mongo
@@ -47,7 +48,6 @@ module TestParliamentarians
 
       # Assert
       assert_not_nil(saved)
-      assert_not_nil(1, saved)
     end
 
     # Test successful get object in mongo

--- a/test/unit/test_mysql_db_manager.rb
+++ b/test/unit/test_mysql_db_manager.rb
@@ -1,0 +1,78 @@
+require 'test/unit'
+require_relative '../../lib/mysql_db_manager'
+require_relative '../../lib/settings'
+
+# This unit test is related to MongoDbManager class
+module Test
+  class TestMysqlDbManager < Test::Unit::TestCase
+
+    # Test the presence of mysql test settings
+    def test_mysql_db_settings_test_is_not_empty
+      assert_not_nil(MYSQL_DB_SETTINGS['test']['name'])
+      assert_not_nil(MYSQL_DB_SETTINGS['test']['host'])
+      assert_not_nil(MYSQL_DB_SETTINGS['test']['port'])
+      assert_not_nil(MYSQL_DB_SETTINGS['test']['username'])
+      assert_not_nil(MYSQL_DB_SETTINGS['test']['password'])
+    end
+
+    # Test the presence of mysql production settings
+    def test_mysql_db_settings_production_is_not_empty
+      assert_not_nil(MYSQL_DB_SETTINGS['production']['name'])
+      assert_not_nil(MYSQL_DB_SETTINGS['production']['host'])
+      assert_not_nil(MYSQL_DB_SETTINGS['production']['port'])
+      assert_not_nil(MYSQL_DB_SETTINGS['production']['username'])
+      assert_not_nil(MYSQL_DB_SETTINGS['production']['password'])
+    end
+
+    # Test the presence of mysql development settings
+    def test_mysql_db_settings_development_is_not_empty
+      assert_not_nil(MYSQL_DB_SETTINGS['development']['name'])
+      assert_not_nil(MYSQL_DB_SETTINGS['development']['host'])
+      assert_not_nil(MYSQL_DB_SETTINGS['development']['port'])
+      assert_not_nil(MYSQL_DB_SETTINGS['development']['username'])
+      assert_not_nil(MYSQL_DB_SETTINGS['development']['password'])
+    end
+
+    # Test successful connection with mysql
+    def test_connection_with_mysql
+      # Setup
+      mdm = MysqlDbManager.new(MYSQL_DB_SETTINGS['test'])
+
+      # Assertion
+      assert_not_nil(mdm)
+      assert_equal(MysqlDbManager, mdm.class)
+    end
+
+    # Test successful object query in mysql
+    def test_query
+      # Setup
+      mysql = MysqlDbManager.new(MYSQL_DB_SETTINGS['test'])
+      query_string = 'SELECT 1, 2, 3'
+
+      # Act
+      result = mysql.query(query_string)
+
+      # Assert
+      assert_not_nil(result)
+      assert_equal(1, result.count)
+    end
+
+    # Test successful save object in mongo
+    def test_save
+      # Setup
+      mysql = MysqlDbManager.new(MYSQL_DB_SETTINGS['test'])
+      object_to_save = {
+          'name' => 'Severino Braga',
+          'email' => 'Sev.Bra@test.com'
+      }
+
+      # Act
+      result = mysql.save(object_to_save, 'test')
+
+      # Assert
+      assert_not_nil(result)
+      assert_equal(1, result['rows_affected'])
+    end
+
+  end
+end

--- a/test/unit/test_suite.rb
+++ b/test/unit/test_suite.rb
@@ -9,6 +9,7 @@ require_relative '../../lib/settings'
 
 # Db Connection
 require_relative 'test_mongo_db_manager'
+require_relative 'test_mysql_db_manager'
 
 # Parliamentarians
 require_relative 'brazil/parliamentarians/test_parliamentarians'

--- a/test/unit/test_suite.rb
+++ b/test/unit/test_suite.rb
@@ -4,6 +4,7 @@
 #   ruby test/unit/test_parliamentarians.rb
 
 # setup
+$ENV = 'test'
 require 'test/unit'
 require_relative '../../lib/settings'
 


### PR DESCRIPTION
Este PR têm por objetivo transformar os dados obtidos do portal da transparência da Câmara dos Vereadores do estado de São Paulo.

A transformação dos dados é feita do mongo db, onde existe a base de extração com dados brutos retirados da fonte. Nesta base mysql queremos estruturar e normalizar os dados para posterior carregamento em outros sistemas como uma API para exposição dos dados.